### PR TITLE
fixes/readme/workflow/ci

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors
+################################################################################
+patreon: srg320

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,116 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors
+################################################################################
+name: "Bug Report"
+description: "Let us know about an unexpected error, a crash, or an incorrect behavior."
+title: 'Title of your Bug Report'
+labels:
+  - bug
+assignees:
+  - srg320
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi there,
+
+        Thank you for opening an issue. Please note that we try to keep the issue tracker reserved for bug reports.
+        Make sure to [search for existing issues](https://github.com/srg320/Saturn_MiSTer/issues?q=label%3Abug) before filing a new one!
+
+  - type: input
+    id: version
+    attributes:
+      label: Version (or build number)
+      placeholder: "20220811"
+      description: |
+        You can find the version in the about dialog.
+
+        If you are not running the latest version, please try upgrading because your issue may have already been fixed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: fpga
+    attributes:
+      label: Single or Dual SDRAM?
+      multiple: false
+      options:
+        - Single (128MB)
+        - Dual (128MB + 32MB)
+        - Dual (128MB + 64MB)
+        - Dual (128MB + 128MB)
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Please list the full steps required to reproduce the issue
+      placeholder: |
+        1. map joystick
+        2. change region
+        3. load game X
+        4. start game X
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: If you want to include screenshots, paste them into the markdown editor below or follow up with a separate comment.
+      placeholder: What were you expecting?
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Debug Output/Crash Output
+      description: |
+        Full debug output can be obtained with UART.
+        Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long.
+        Share a link to a GitHub Gist containing the output of the `crash.log` file.
+      placeholder: |
+        https://gist.github.com/myuser/e6cb69a18488cbd420d5bafdd6bf0ba
+    validations:
+      required: false
+
+  - type: textarea
+    id: bug_context
+    attributes:
+      label: Additional Context
+      description: |
+        Are there anything atypical about your situation that we should know?
+        For example: Running on an unsupported device? Are you passing any unusual command line options?
+    validations:
+      required: false
+
+  - type: textarea
+    id: bug_config_file
+    attributes:
+      label: Configuration Files
+      placeholder: |
+        Paste the relevant parts of your `.ini` configuration file.
+    validations:
+      required: false
+
+  - type: input
+    id: bug_firmware
+    attributes:
+      label: Opened Issues and Pull Requests
+      placeholder: "#1234"
+      description: |
+        Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example: #1234
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/QUESTION.yml
+++ b/.github/ISSUE_TEMPLATE/QUESTION.yml
@@ -1,0 +1,29 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021, The Raetro authors and contributors
+################################################################################
+name: "Question"
+description: "Ask a question about the project."
+title: 'Title of your Question'
+labels:
+  - question
+assignees:
+  - srg320
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi there,
+
+        Please note that we try to keep the issue tracker reserved for bug reports.
+        Make sure to [search for existing questions](https://github.com/srg320/Saturn_MiSTer/issues?q=label%3Aquestion) before filing a new one!
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Ask a question about the Sega Saturn Compatible FPGA Core
+      placeholder: |
+        Ask your question here! Please keep the questions related to the FPGA Core only.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileType: TEXT -->
+<!-- SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors -->
+
+<!-- Thank you for your contribution! Please replace {Please write here} with your description -->
+
+## What does this do / why do we need it?
+
+<!--
+Please include a summary of the change and which issue is fixed.
+Please also include relevant motivation and context.
+List any dependencies that are required for this change.
+-->
+
+{Please write here}
+
+Fixes # (issue)
+
+## Type of change
+
+<!--
+Please delete options that are not relevant.
+-->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Coding style (indentation, etc)
+- [ ] {Please write custom change here}
+
+## What should a reviewer look out for in this PR?
+
+<!--
+Please describe the tests that you ran to verify your changes.
+Provide instructions so we can reproduce.
+Please also list any relevant details for your test configuration
+-->
+
+{Please write here}
+
+## Additional Comments (if any)
+
+{Please write here}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors
+################################################################################
+name: Release (Single and Dual SDRAM)
+################################################################################
+# How to create a tag to launch the workflow
+# git tag 20221231
+# git push origin --tags
+################################################################################
+on:
+  push:
+    tags:
+      - '*' # Trigger only when tagged, i.e. 20221231
+################################################################################
+jobs:
+  synthesis:
+    runs-on: ubuntu-latest
+    container: raetro/quartus:17.0
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # 1 - Checkout repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # 2 - Checkout SH-2
+      - name: Checkout SH-2
+        uses: actions/checkout@v3
+        with:
+          repository: srg320/SH
+          path: SH
+      # 3 - Checkout Saturn
+      - name: Checkout Saturn
+        uses: actions/checkout@v3
+        with:
+          repository: srg320/Saturn
+          path: Saturn
+      # 4 - Change Path to Required Projects
+      - name: Fix files.qip paths
+        run: |
+          sed -i 's/..\/SH\//SH\//g' files.qip
+          sed -i 's/..\/Saturn\//Saturn\//g' files.qip
+      # 5 - RTL synthesis Single SDRAM
+      - name: Run compilation flow for Single SDRAM
+        run: quartus_sh --flow compile Saturn.qpf
+      # 6 - RTL synthesis Dual SDRAM
+      - name: Run compilation flow for Dual SDRAM
+        run: quartus_sh --flow compile Saturn_DS.qpf
+      # 7 - Get current version for tagging binary
+      - name: Get the version
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/} # Get the version from the tag
+      # 8 - Create tag with version and SHA256 checksum
+      - name: Copy, tag with version and create SHA256 checksum
+        run: |
+          mkdir -p releases
+          cp output_files/Saturn.rbf releases/Saturn_${{ steps.version.outputs.version }}.rbf
+          cp output_files/Saturn_DS.rbf releases/Saturn_DS_${{ steps.version.outputs.version }}.rbf
+          ( cd output_files && sha256sum Saturn.rbf > ../releases/Saturn_${{ steps.version.outputs.version }}.rbf.sha256 )
+          ( cd output_files && sha256sum Saturn_DS.rbf > ../releases/Saturn_DS_${{ steps.version.outputs.version }}.rbf.sha256 )
+      # 9 - Create a new GitHub release and upload the distribution artifacts
+      - name: Create a new GitHub release
+        uses: softprops/action-gh-release@v0.1.14
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            releases/Saturn_${{ steps.version.outputs.version }}.rbf
+            releases/Saturn_${{ steps.version.outputs.version }}.rbf.sha256
+            releases/Saturn_DS_${{ steps.version.outputs.version }}.rbf
+            releases/Saturn_DS_${{ steps.version.outputs.version }}.rbf.sha256
+      # 9 - Commit Binary to Repository (aka. the MiST(er) way)
+      #- name: Commit release back to repository
+      #  run: |
+      #    git fetch
+      #    git checkout -b master
+      #    git config user.name github-actions
+      #    git config user.email github-actions@github.com
+      #    git add releases/Saturn_${{ steps.version.outputs.version }}.rbf
+      #    git add releases/Saturn_DS_${{ steps.version.outputs.version }}.rbf
+      #    git commit -m "Release ${{ steps.version.outputs.version }}"
+      #    git push origin master

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,7 +1,22 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors
+################################################################################
 name: Test Build (Single SDRAM)
-
-on: [push, workflow_dispatch]
-
+################################################################################
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '.github/FUNDING.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+    paths-ignore:
+      - '**.md'
+################################################################################
 jobs:
   synthesis:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build_ds.yml
+++ b/.github/workflows/test-build_ds.yml
@@ -1,7 +1,22 @@
+################################################################################
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileType: OTHER
+# SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors
+################################################################################
 name: Test Build (Dual SDRAM)
-
-on: [push, workflow_dispatch]
-
+################################################################################
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '.github/FUNDING.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+    paths-ignore:
+      - '**.md'
+################################################################################
 jobs:
   synthesis:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,32 +1,130 @@
-Saturn_DS - dual SDRAM build (recommended).
+# [Sega Saturn](https://en.wikipedia.org/wiki/Sega_Saturn) Compatible IP Core for FPGA
 
-Saturn - single SDRAM build.
+![Active Development](https://img.shields.io/badge/Maintenance%20Level-Actively%20Developed-brightgreen.svg)
+[![Test Build (Single SDRAM)](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build.yml/badge.svg?branch=master&event=push)](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build.yml)
+[![Test Build (Dual SDRAM)](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build_ds.yml/badge.svg?branch=master&event=push)](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build_ds.yml)
+[![Funding](https://img.shields.io/endpoint?url=https://shieldsio-patreon.vercel.app/api/?username=srg320&type=patrons)](https://www.patreon.com/srg320)
+[![Twitter Follow](https://img.shields.io/twitter/follow/srg320_?style=social)](https://twitter.com/srg320_)
 
-!!For both builds the first SDRAM module must be 128Mb (i.e. with two chips)!!
+> **WARNING**: This repository is in active development. There are no guarantees about stability. Breaking changes will occur until a stable release is made and announced.
 
+## Overview
 
+The Saturn was a 32-bit console by Sega, released in 1994 in Japan and 1995 in North America and Europe. Sega designed its Saturn with advanced hardware and with dual CPUs, making it difficult for programmers. In addition, components were not specifically created to work together, graphics hardware was complex, and the system's basic geometric primitive was based on quadrilaterals which proved difficult for Sega because the rest of the industry based its design on triangles. Eventually, the Saturn was eclipsed by the release of Sega's own Dreamcast.
 
+## Technical specifications
 
+- **CPU**: 2x Hitachi SH2 32-bit RISC CPUs @ 28.63 MHz
+- **RAM**: 16Mbit SDRAM
+- **VRAM**: 12Mbit SDRAM
+- **Graphics**:
+  - Sega/Hitachi VDP1 @ 28.63 MHz (sprite/texture and polygons)
+  - Sega/Yamaha VDP2 @ 28.63 MHz (background, scroll and 3D)
+- **Resolution**: 320x224 to 704x224, 16,777,216 millions colors
+- **Sound CPU**: Motorola 68ECOO @ 22.6 MHz
+- **Sound Processor**: Yamaha SCSP (Saturn Custom Sound Processor) YMF292
+- **Media**: CD-ROM
 
-## Status
+## Hardware Requirements
 
-VDP2: 
+- 128 MB SDRAM Module (Primary)
+- SDRAM Module of any size (32MB-128MB) (Secondary)
 
--missing PAL mode.
+> **Note:** Dual SDRAM modules is recommended for better compatibility.
 
--missing interlace mode.
+## Test Builds
 
--missing Line Screen.
+Test builds can be downloaded from the GitHub Actions, they are automatic generated on push against the current code of the repository and should not be considered releases.
 
--missing Mosaic.
+To download select a workflow bellow, click on the most recent run and download the zip file under `Artifacts produced during runtime`.
 
+- [Single SDRAM](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build.yml)
+- [Dual SDRAM](https://github.com/srg320/Saturn_MiSTer/actions/workflows/test-build_ds.yml)
 
-VDP1: 
+> **Note:** Actions has a 90-day retention rule by default, after that the artifacts are not available anymore.
 
--framebuffer size is limited to 352x256 pixels (instead of 512x256), so some games that use the framebuffer as temporary data storage (e.g., Burning Rangers) do not work.
+## Building
 
--missing gouraud shading.
+### Prerequisites
 
-SCSP:
+To build this project you also need the following repositories [Saturn](https://github.com/srg320/Saturn) and [SH](https://github.com/srg320/SH)
 
--missing DSP.
+### Cloning the Repositories
+
+```bash
+git clone https://github.com/srg320/Saturn_MiSTer.git
+git clone https://github.com/srg320/Saturn.git
+git clone https://github.com/srg320/SH.git
+```
+
+The repositories must be on the same level:
+
+```bash
+.
+├── SH
+├── Saturn
+└── Saturn_MiSTer
+```
+
+### Project Files
+
+Inside the folder `Saturn_MiSTer` you will find 2 Quartus project files.
+
+- `Saturn.qpf` - Build project for usage with Single SDRAM.
+- `Saturn_SD.qpf` - Build project for usage with Dual SDRAM (**recommended**).
+
+> **Note:** For both builds the primary SDRAM module must be 128MB (i.e. with two chips)!
+
+## Compatible BIOS
+
+> **BIOS NOT INCLUDED:** In order to use this core, you need to provide your own BIOS.
+
+Rename your Saturn bios file to `boot.rom` and place it in the `games/Saturn/` folder.
+
+| Console           | Version | Region | SHA1                                     | Size   | Status |
+|-------------------|---------|--------|------------------------------------------|--------|:------:|
+| Sega Saturn       | 1.00    | Japan  | 2b8cb4f87580683eb4d760e4ed210813d667f0a2 | 512 KB |   ✅    |
+| Sega Saturn       | 1.00a   | USA    | 3bb41feb82838ab9a35601ac666de5aacfd17a58 | 512 KB |   ✅    |
+| Sega Saturn       | 1.00    | Europe | faa8ea183a6d7bbe5d4e03bb1332519800d3fbc3 | 512 KB |   ✅    |
+| Sega Saturn       | 1.003   | Japan  | 7b23b53d62de0f29a23e423d0fe751dfb469c2fa | 512 KB |   ❌    |
+| Sega Saturn       | 1.01    | Japan  | df94c5b4d47eb3cc404d88b33a8fda237eaf4720 | 512 KB |   ✅    |
+| Sega Saturn       | 1.01a   | USA    | faa8ea183a6d7bbe5d4e03bb1332519800d3fbc3 | 512 KB |   ✅    |
+| Hitachi Hi-Saturn | 1.01    | Japan  | 49d8493008fa715ca0c94d99817a5439d6f2c796 | 512 KB |   ✅    |
+| Hitachi Hi-Saturn | 1.02    | Japan  | 8a22710e09ce75f39625894366cafe503ed1942d | 512 KB |   ✅    |
+| Hitachi Hi-Saturn | 1.03    | Japan  | 8c031bf9908fd0142fdd10a9cdd79389f8a3f2fc | 512 KB |   ✅    |
+| Victor V-Saturn   | 1.01    | Japan  | 4154e11959f3d5639b11d7902b3a393a99fb5776 | 512 KB |   ✅    |
+
+> **Note:** You can also place a file named `cd_bios.rom` in the same directory as the CD image. This can be used for games that depend on a specific BIOS.
+
+## Status of Features (Not yet Prioritized)
+
+> Work in progress, don't report any bugs!
+
+### Video Display Processor 1 (VDP1)
+
+- [ ] 512×256 Framebuffer (current size is limited to 352x256 pixels). *Games that make usage of the framebuffer as temporary data storage will not work (e.g., Burning Rangers)*
+- [ ] Gouraud Shading
+
+### Video Display Processor 2 (VDP2)
+
+- [ ] PAL Mode
+- [ ] Interlaced Mode
+- [ ] Line Screen
+- [ ] Mosaic
+
+### Yamaha SCSP (Saturn Custom Sound Processor) YMF292
+
+- [ ] Yamaha FH1 DSP (Digital Signal Processor)
+
+## Credits and acknowledgment
+
+Made with ❤️ by [Sergey Dvodnenko](https://twitter.com/srg320_).
+
+- To all my [Patreon](https://www.patreon.com/srg320) supporters. Your support keeps me working on the core and helps me bring it to life.
+- Jorge Cwik - FX68K 68000 SystemVerilog core.
+
+## Legal Notice
+
+Sega Saturn™ - Copyright © 1994, 1995 SEGA ENTERPRISES, LTD. All rights reserved. SEGA and the SEGA logo are registered trademarks of SEGA CORPORATION. All other trademarks, logos, and copyrights are property of their respective owners.
+
+The authors and contributors or any of its maintainers are in no way associated with or endorsed by SEGA®.


### PR DESCRIPTION
## What does this do?

- docs(readme): update readme
  - add badges
  - add information about hardware
  - add compatible BIOS
  - add legal notice
  - refactor status
  - add credits
- feat(github): add FUNDING file
- fix(test-build): ignore changes on files that shouldn't trigger a workflow run
- build(release): add workflow for release triggered by a new tag
- ci(github): add pull request template
- ci(github): add issues template for question and bug report

## Type of change

- [x] MISC changes noted above.

## Additional Comments (if any)

About triggering a new release:
A new `release.yml` workflow was added to create a new release and publish it.
It requires a tag in order to trigger a run, you can do so by doing:

```bash
git tag 20221231
git push origin --tags
```

The file is configured to use the release system of GitHub instead of commit the binary back to the repository.
An additional step is comment out in case you want to commit the binaries back into a `releases` folder the way MiSTer does.