### PR TITLE
SMPC joystick peripheral handling

### DIFF
--- a/Saturn.sv
+++ b/Saturn.sv
@@ -257,8 +257,8 @@ module emu
 	
 		"P2,Input;",
 		"P2-;",
-		"P2OFH,Pad 1,Digital,Off,Analog,Wheel,Lightgun;",
-		"P2OIK,Pad 2,Digital,Off,Analog,Wheel,Lightgun;",
+		"P2OFH,Pad 1,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission,Lightgun;",
+		"P2OIK,Pad 2,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission,Lightgun;",
 		"-;",
 		
 `ifndef DEBUG

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -257,8 +257,8 @@ module emu
 	
 		"P2,Input;",
 		"P2-;",
-		"P2OFH,Pad 1,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission,Lightgun;",
-		"P2OIK,Pad 2,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission,Lightgun;",
+		"P2OFH,Pad 1,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission;",
+		"P2OIK,Pad 2,Digital,Off,Wheel,Mission Stick,3D Pad,Dual Mission;",
 		"-;",
 		
 `ifndef DEBUG

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -705,6 +705,12 @@ module emu
 			
 		.JOY1(joy1),
 		.JOY2(joy2),
+
+		.JOY1_X(joy0_x),
+		.JOY1_Y(joy0_y),
+		.JOY2_X(joy1_x),
+		.JOY2_Y(joy1_y),
+
 		.JOY1_TYPE(status[17:15]),
 		.JOY2_TYPE(status[20:18]),
 		

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -235,7 +235,7 @@ module emu
 	// 0         1         2         3          4         5         6   
 	// 01234567890123456789012345678901 23456789012345678901234567890123
 	// 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-	// XXXX XXXXXXXXXXX                 XXXXXXXXXXXXX                 
+	// XXXX XXXXXXXXXXXXXXXX            XXXXXXXXXXXXX                 
 	
 	`include "build_id.v"
 	localparam CONF_STR = {
@@ -257,7 +257,9 @@ module emu
 	
 		"P2,Input;",
 		"P2-;",
-		"P2OF,Pad 2,Disable,Enable;",
+		"P2OFH,Pad 1,Digital,Off,Analog,Wheel,Lightgun;",
+		"P2OIK,Pad 2,Digital,Off,Analog,Wheel,Lightgun;",
+		"-;",
 		
 `ifndef DEBUG
 		"P3,Debug;",
@@ -491,6 +493,7 @@ module emu
 							  ~joystick_0[8],~joystick_0[9],~joystick_0[10],~joystick_0[11],~joystick_0[12],3'b111};
 	wire [15:0] joy2 = {~joystick_1[0],~joystick_1[1],~joystick_1[2],~joystick_1[3],~joystick_1[7],~joystick_1[4],~joystick_1[6],~joystick_1[5],
 							  ~joystick_1[8],~joystick_1[9],~joystick_1[10],~joystick_1[11],~joystick_1[12],3'b111};
+
 	
 	wire [24:0] MEM_A;
 	wire [31:0] MEM_DI;
@@ -702,7 +705,8 @@ module emu
 			
 		.JOY1(joy1),
 		.JOY2(joy2),
-		.JOY2_EN(status[15]),
+		.JOY1_TYPE(status[17:15]),
+		.JOY2_TYPE(status[20:18]),
 		
 		.SCRN_EN(SCRN_EN & SCRN_EN2),
 		.SND_EN(SND_EN & SND_EN2),

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -287,7 +287,7 @@ module emu
 	wire [63:0] status;
 	wire  [1:0] buttons;
 	wire [12:0] joystick_0,joystick_1,joystick_2,joystick_3,joystick_4;
-	wire  [7:0] joy0_x,joy0_y,joy1_x,joy1_y;
+	wire  [7:0] joy0_x0,joy0_y0,joy0_x1,joy0_y1,joy1_x0,joy1_y0,joy1_x1,joy1_y1;
 	wire        ioctl_download;
 	wire        ioctl_wr;
 	wire [24:0] ioctl_addr;
@@ -326,8 +326,10 @@ module emu
 		.joystick_2(joystick_2),
 		.joystick_3(joystick_3),
 		.joystick_4(joystick_4),
-		.joystick_l_analog_0({joy0_y, joy0_x}),
-		.joystick_l_analog_1({joy1_y, joy1_x}),
+		.joystick_l_analog_0({joy0_y0, joy0_x0}),
+		.joystick_l_analog_1({joy1_y0, joy1_x0}),
+		.joystick_r_analog_0({joy0_y1, joy0_x1}),
+		.joystick_r_analog_1({joy1_y1, joy1_x1}),
 	
 		.buttons(buttons),
 		.forced_scandoubler(forced_scandoubler),
@@ -706,10 +708,14 @@ module emu
 		.JOY1(joy1),
 		.JOY2(joy2),
 
-		.JOY1_X(joy0_x),
-		.JOY1_Y(joy0_y),
-		.JOY2_X(joy1_x),
-		.JOY2_Y(joy1_y),
+		.JOY1_X1(joy0_x0),
+		.JOY1_Y1(joy0_y0),
+		.JOY1_X2(joy0_x1),
+		.JOY1_Y2(joy0_y1),
+		.JOY2_X1(joy1_x0),
+		.JOY2_Y1(joy1_y0),
+		.JOY2_X2(joy1_x1),
+		.JOY2_Y2(joy1_y1),
 
 		.JOY1_TYPE(status[17:15]),
 		.JOY2_TYPE(status[20:18]),


### PR DESCRIPTION
<!-- SPDX-License-Identifier: CC0-1.0 -->
<!-- SPDX-FileType: TEXT -->
<!-- SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors -->

<!-- Thank you for your contribution! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This change adds SMPC peripheral handling for the Arcade Racer wheel controller, the Mission Stick (single and dual configurations), and the Saturn 3D Pad.

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] New feature (non-breaking change which adds functionality)

## What should a reviewer look out for in this PR?

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

Pad SMPC data and OREG values were checked in the SmpcTest_1 and sdm_repack_2 ROMs, and was consistent with the pads' behavior in Mednafen. I also spot-checked the behavior of each pad using a compatible game. For example, SmpcTest_1 displays the Dual Mission Stick as an invalid input, but the dual stick seemed to work fine in Panzer Dragoon II Zwei.

## Additional Comments (if any)

This PR only implements SMPC handling for these peripherals, so anything using SH-2 Direct for anything except the gamepad still won't work yet.

For now, only joysticks are supported - no mouse, keyboard, etc.

Analog triggers are not yet available in the framework, so those are just set to 0 for now. Ideally, the framework will be changed so that analog trigger data is also passed through hps_io and made available to the core.
